### PR TITLE
Specified utf-8 encoding for DESCRIPTION files

### DIFF
--- a/g_octave/description.py
+++ b/g_octave/description.py
@@ -68,7 +68,7 @@ class Description(object):
         # current key
         key = None
 
-        with open(file, 'r') as fp:
+        with open(file, 'r', encoding="utf-8") as fp:
             for line in fp:
                 line_splited = line.split(':')
 


### PR DESCRIPTION
It seems utf-8 is used by some packages such as image and physicalconstants