### PR TITLE
Fix python2 compat for open in description.py

### DIFF
--- a/g_octave/description.py
+++ b/g_octave/description.py
@@ -32,7 +32,7 @@ from contextlib import closing
 
 from .config import Config
 from .exception import ConfigException, DescriptionException
-from .compat import py3k
+from .compat import py3k, open
 
 if py3k:
     import urllib.request as urllib


### PR DESCRIPTION
Fixes

```
# g-octave --update
 * Unknown error - 'encoding' is an invalid keyword argument for this function
```

when run under python 2.7
